### PR TITLE
Bugfix: the exception ENOTFOUND crashed NodeJS

### DIFF
--- a/src/get-header.ts
+++ b/src/get-header.ts
@@ -35,8 +35,12 @@ export default function (url: string): Promise<any> {
 			: null;
 
 		/* reject when not supported protocol */
-		if (req === null) reject("not-supported-protocol");
-
-		req.end();
+		if (req === null) {
+			reject("not-supported-protocol");
+		}
+        else {
+			req.on('error', error => reject(error));
+			req.end();
+		}
 	});
 }

--- a/src/get-header.ts
+++ b/src/get-header.ts
@@ -39,7 +39,7 @@ export default function (url: string): Promise<any> {
 			reject("not-supported-protocol");
 		}
 		else {
-			req.on('error', error => reject(error));
+			req.on("error", error => reject(error));
 			req.end();
 		}
 	});

--- a/src/get-header.ts
+++ b/src/get-header.ts
@@ -38,7 +38,7 @@ export default function (url: string): Promise<any> {
 		if (req === null) {
 			reject("not-supported-protocol");
 		}
-        else {
+		else {
 			req.on('error', error => reject(error));
 			req.end();
 		}


### PR DESCRIPTION
If a URL is invalid, an exception will be thrown and it can not be caught:

events.js:182
      throw er; // Unhandled 'error' event
      ^
Error: getaddrinfo ENOTFOUND www.domain.com www.domain.com:80
    at errnoException (dns.js:53:10)
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:95:26)
	
Also, reject does not stop processing: if req is null, req.end() will throw an exception.
Can you publish a new version on NPM please?